### PR TITLE
Implement configuration loading in map

### DIFF
--- a/config.go
+++ b/config.go
@@ -371,7 +371,13 @@ func addMapDefaults(to, from reflect.Value) {
 	from = reflect.Indirect(from)
 	for _, key := range from.MapKeys() {
 		f := to.MapIndex(key)
-		docopy(f, from.MapIndex(key))
+		if reflect.DeepEqual(f.Interface(), reflect.Zero(f.Type()).Interface()) {
+			if !f.CanSet() {
+				log.Printf("Config: Cannot set default value for key %s of %s", key, f.Type().Name())
+				continue
+			}
+			docopy(f, from.MapIndex(key))
+		}
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -318,7 +318,14 @@ func (c *Config) register(name string, defaults interface{}, r Reconfigurable) {
 		}
 	}
 	if defaults != nil {
-		addDefaults(c.sections[name].defaults, v)
+		d := c.sections[name].defaults
+		switch d.Type().Kind() {
+		case reflect.Struct:
+			addStructDefaults(d, v)
+		case reflect.Map:
+			addMapDefaults(d, v)
+		default:
+		}
 		if c.sections[name].current == nil {
 			c.sections[name].current = defaults
 			c.current[name] = defaults
@@ -359,7 +366,16 @@ func (s *section) change() {
 	}
 }
 
-func addDefaults(to, from reflect.Value) {
+func addMapDefaults(to, from reflect.Value) {
+	to = reflect.Indirect(to)
+	from = reflect.Indirect(from)
+	for _, key := range from.MapKeys() {
+		f := to.MapIndex(key)
+		docopy(f, from.MapIndex(key))
+	}
+}
+
+func addStructDefaults(to, from reflect.Value) {
 	to = reflect.Indirect(to)
 	from = reflect.Indirect(from)
 	for i := 0; i < to.NumField(); i++ {

--- a/config_test.go
+++ b/config_test.go
@@ -55,6 +55,25 @@ func (t *testSliceCfg) changeCount() int {
 	return t.changed
 }
 
+type testCfgMap map[string]int
+
+func (t *testCfgMap) Changed() {
+	m := *t
+	if _, ok := m["changed"]; !ok {
+		m["changed"] = 0
+	}
+	m["changed"]++
+}
+
+func (t *testCfgMap) changeCount() int {
+	m := *t
+	if c, ok := m["changed"]; ok {
+		return c
+	} else {
+		return 0
+	}
+}
+
 type testClass struct {
 	cfg     *testCfg
 	changed int
@@ -235,6 +254,19 @@ key=bar
 			defaults:    func() changeCounter { return &testSliceCfg{} },
 			afterLoad:   &testSliceCfg{changed: 1},
 			afterUpdate: &testSliceCfg{Key: []string{"foo", "bar"}, changed: 2},
+		},
+		testCase{
+			name: "yaml map",
+			raw: `section:
+  key: 21
+`,
+			rawUpdated: `section:
+  key: 42
+`,
+			loader:      &yamlLoader{},
+			defaults:    func() changeCounter { return &testCfgMap{} },
+			afterLoad:   &testCfgMap{"key": 21, "changed": 1},
+			afterUpdate: &testCfgMap{"key": 42, "changed": 2},
 		},
 	}
 )


### PR DESCRIPTION
Configuration could be loaded directly in `map` instead of in `struct`.
